### PR TITLE
README: correct how-to instructions

### DIFF
--- a/README.md
+++ b/README.md
@@ -37,7 +37,7 @@ Note: Before starting, please ensure you have the Daml SDK installed. You can fi
 
 # How to run
 
-In the quickstart directory, compile Daml model with: 
+In the project directory, compile Daml model with: 
 
     daml build
 


### PR DESCRIPTION
There is no quickstart directory, the commands should be just run in the project root.